### PR TITLE
[DIG2021-1318] Let sb campaign request url be base url

### DIFF
--- a/lib/blurb/request_collection_with_campaign_type.rb
+++ b/lib/blurb/request_collection_with_campaign_type.rb
@@ -5,7 +5,7 @@ class Blurb
 
     def initialize(campaign_type:, resource:, base_url:, headers:, bulk_api_limit: 100)
       @campaign_type = campaign_type
-      base_url = campaign_type.to_s == 'sd' or campaign_type.to_s == 'sb' ? base_url : "#{base_url}/v2"
+      base_url = campaign_type.to_s == 'sp' ? "#{base_url}/v2" : base_url
       @base_url = "#{base_url}/#{@campaign_type}/#{resource}"
       @headers = headers
       @api_limit = bulk_api_limit


### PR DESCRIPTION
The Amazon documentation states that sb campaigns call should use end point '/sb/campaigns' without v2.
![image](https://user-images.githubusercontent.com/68452870/136731947-76b41910-39fa-4e3c-8415-ae4a42100a23.png)
